### PR TITLE
Add new example keyboard, support for a new TRS socket, and minor fixes to the MCU generation.

### DIFF
--- a/example_layouts/split_cloud/LICENSE
+++ b/example_layouts/split_cloud/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 coolsa
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/example_layouts/split_cloud/README.md
+++ b/example_layouts/split_cloud/README.md
@@ -1,0 +1,7 @@
+# Split-Cloud handwired keyboard
+
+The Split-Cloud is a split ortholinear 5x12 layout, forked from the Preonic and Nyquist keyboard models.
+
+![Split-Cloud](https://raw.githubusercontent.com/coolsa/cloud-keyboard/main/images/finalProduct.jpg)
+
+Check out the [source and build log here!](https://github.com/coolsa/cloud-keyboard)

--- a/example_layouts/split_cloud/parameters.scad
+++ b/example_layouts/split_cloud/parameters.scad
@@ -1,0 +1,225 @@
+/* PCB Parameters */
+// Diameter of row/column wire channels
+wire_diameter = 2.15;
+// Upward angle of switch pin in contact with diode anode (gives more reliable
+// connections but slightly deforms pin)
+diode_pin_angle = 5;  // [0:15]
+// Amount the diode folds over
+diode_foldover = 4;
+// Overall thickness of PCB
+pcb_thickness = 4;  // [4:0.1:10]
+
+/* Switch Parameters */
+// Switch type
+switch_type = "mx";  // [mx, choc]
+// Switch orientation (based on LED location)
+switch_orientation = "south";  // [north, south]
+// Whether to use experimental diode leg contact
+use_folded_contact = true;
+
+
+/* Stabilizer Parameters */
+stabilizer_type = "pcb";  // [pcb, plate]
+
+
+/* Case Parameters */
+// Type of case to generate
+case_type = "plate_case";  // [sandwich, plate_case, backplate_case]
+// Thickness of case walls
+case_wall_thickness = 2;
+// Case wall draft angle (convex cases only)
+case_wall_draft_angle = 15;
+// Width of the case chamfer (convex cases only)
+case_chamfer_width = 1;
+// Angle of the case chamfer (convex cases only)
+case_chamfer_angle = 45;
+// Height of the vertical portion at the bottom of the case 
+// (not including backplate flange)
+case_base_height = 2;
+// Fit tolerance between interlocking case parts
+case_fit_tolerance = 0.2;
+// Tenting angle around x-axis
+tent_angle_x = 3;
+// Tenting angle around y-axis (i.e. typing angle)
+tent_angle_y = 0;
+// Point around which keyboard is tented
+tent_point = [0,8.125*19.05];
+
+
+/* Plate Parameters */
+// Distance the plate sticks out past the PCB
+plate_margin = 5;
+// Radius of outer fillets
+plate_outer_fillet = 2.5;
+// Radius of inner fillets
+plate_inner_fillet = 50;
+// Setting this lower can help fix geometry issues when using custom plate shapes
+// (i.e. two components that don't meet at exactly the same point can cause offset issues)
+plate_precision = 1/100;
+
+
+/* Backplate Parameters */
+// Thickness of the backplate
+backplate_thickness = 2;
+// Thickness of flange around backplate if using an integrated-plate case
+backplate_case_flange = 1;
+// Spacing between the bottom of the PCB and the top of the backplate
+pcb_backplate_spacing = 4;
+
+
+/* MCU Parameters (Default values for Pro Micro) */
+mcu_type = "bare";  // [bare, socketed]
+mcu_width = 18.5;
+mcu_length = 33.3;
+mcu_height = 4.25;  // Distance to top of PCB
+mcu_row_spacing = 15.24;
+mcu_row_count = 2;  // Unused
+mcu_pin_count = 24;
+mcu_pin_pitch = 2.54;
+mcu_pin_offset = 0.3;  // Offset from the rear of the PCB
+mcu_connector_width = 13;  // Width of the connector (for plate cutout)
+mcu_connector_length = 4;  // Distance the connector extends onto the MCU (for plate cutout)
+mcu_connector_height = 8;  // Height of the plug housing
+mcu_connector_offset = 2; // Vertical offset of plug center from PCB center
+mcu_pcb_thickness = 1.6;
+mcu_socket_width = mcu_width+4;
+mcu_socket_length = mcu_length+4;
+expose_mcu = false;
+grid_size = 8;
+grid_spacing = 1.6;
+
+
+/* TRRS Socket Parameters */
+//trrs_type = "pj320a";
+//trrs_width = 6;
+//trrs_length = 12.1;
+//trrs_height = 5;
+//trrs_flange_length = 2;
+//trrs_flange_diameter = 5;
+//trrs_pin_spacing = 4.4;
+//trrs_nub_diameter = 1.5;  // Little locating nubs on the bottom of the socket
+//trrs_nub_height = 1;
+//trrs_nub_spacing = 7;
+//trrs_nub_offset = 1.5;  // Distance from the front of the socket (not including flange)
+//trrs_plug_width = 10;  // Width of a plug for plate clearance
+
+
+/* TRS Socket Parameters */
+trrs_type = "pj324m";
+trrs_width = 11.55;
+trrs_length = 14.25;
+trrs_height = 6.3;
+trrs_flange_length = 3.5;
+trrs_flange_diameter = 6;
+trrs_pin_spacing = 4.4;
+trrs_nub_diameter = 1.5;  // Little locating nubs on the bottom of the socket
+trrs_nub_height = 1;
+trrs_nub_spacing = 7;
+trrs_nub_offset = 1.5;  // Distance from the front of the socket (not including flange)
+trrs_plug_width = 10;  // Width of a plug for plate clearance
+
+
+/* Via Parameters */
+via_width = 5;
+via_length = 15;
+via_shape = [via_width, via_length];
+
+
+/* Standoff Parameters */
+// Component the standoff is integrated with
+standoff_integration_default = "plate";  // [plate, backplate, pcb, separate, none]
+// Component the standoff is screwed to
+standoff_attachment_default = "pcb";  // [plate, backplate, pcb, plate_backplate, none]
+// Intermediate shape variable to pass around
+standoff_config_default = [
+    standoff_integration_default,
+    standoff_attachment_default
+];
+// Diameter of integrated standoffs
+standoff_diameter = 4.5;
+// Diameter of standoff clearance hole
+standoff_clearance_hole_diameter = 2.5;
+// Diameter of standoff pilot hole
+standoff_pilot_hole_diameter = 1.6;
+// Diameter of standoff screw head counterbores
+standoff_counterbore_diameter = 4.5;
+
+
+/* Misc Parameters */
+// Increase this if your standoffs are a bit too long due to printing tolerances
+fit_tolerance = 0;
+// Resolution of holes (affects render times)
+$fn=12;
+
+
+/* Advanced Parameters (related to switch size) */
+// Switch spacing distance
+unit = 19.05;
+// Horizontal unit size (18mm for choc keycaps)
+h_unit = unit;
+// Vertical unit size (17mm for choc keycaps)
+v_unit = unit;
+// Spacing of grid for MX pins
+grid = 1.27;
+// Size of socket body
+socket_size =
+    switch_type == "mx"
+    ? 14
+    : switch_type == "choc"
+        ? 15
+        : assert(false, "switch_type is invalid");
+// Depth of the socket holes
+socket_depth = 3.5;
+// Thickness of the plate
+plate_thickness =
+    switch_type == "mx"
+    ? 1.5
+    : switch_type == "choc"
+        ? 1.3
+        : assert(false, "switch_type is invalid");
+// Size of the plate cutout
+plate_cutout_size =
+    switch_type == "mx"
+    ? 14
+    : switch_type == "choc"
+        ? 13.8
+        : assert(false, "switch_type is invalid");
+// Spacing between the top of the PCB and top of the plate
+pcb_plate_spacing =
+    switch_type == "mx"
+    ? 5
+    : switch_type == "choc"
+        ? 2.2
+        : assert(false, "switch_type is invalid");
+
+// Total assembly thickness (for reference)
+total_thickness =
+    pcb_plate_spacing + pcb_thickness + pcb_backplate_spacing + backplate_thickness;
+
+// Width of a border unit around the socket (for joining adjacent sockets)
+border_width = (unit - socket_size)/2;
+h_border_width = (h_unit - socket_size)/2;
+v_border_width = (v_unit - socket_size)/2;
+
+// Conversion factor from border width to mm (for use in layouts)
+mm = 1/border_width;
+h_mm = 1/h_border_width;
+v_mm = 1/v_border_width;
+
+// Align mcu to a unit
+mcu_unit_resolution = .5;  // Grid size to snap to (as fractional unit)
+mcu_h_unit_size = ceil(mcu_socket_width/mcu_unit_resolution/h_unit) * mcu_unit_resolution;
+mcu_v_unit_size = ceil(mcu_socket_length/mcu_unit_resolution/v_unit) * mcu_unit_resolution;
+
+// Useful for manipulating layout elements
+function slice(array, bounds, extra_data_override="") = [
+    let(
+        lower = bounds[0] >= 0 ? bounds[0] : max(len(array)+bounds[0], 0),
+        upper = bounds[1] > 0 ? min(bounds[1], len(array)) : len(array)+bounds[1],
+        step = len(bounds) == 3 ? bounds[2] : 1
+    )
+    for (i = [lower:step:upper-1])
+       len(array[i]) >= 2 && extra_data_override != ""
+            ? [array[i][0], array[i][1], extra_data_override]
+            : array[i]
+];

--- a/example_layouts/split_cloud/split_cloud.json
+++ b/example_layouts/split_cloud/split_cloud.json
@@ -1,0 +1,111 @@
+[
+  [
+    {
+      "f": 1
+    },
+    "\n\n`\n\n\n\n\n\n\n`",
+    "\n\n1\n\n\n\n\n\n\n1",
+    "\n\n2\n\n\n\n\n\n\n2",
+    "\n\n3\n\n\n\n\n\n\n3",
+    "\n\n4\n\n\n\n\n\n\n4",
+    "\n\n5\n\n\n\n\n\n\n5",
+    {
+      "x": 2
+    },
+    "\n\n6\n\n\n\n\n\n\n6",
+    "\n\n7\n\n\n\n\n\n\n7",
+    "\n\n8\n\n\n\n\n\n\n8",
+    "\n\n9\n\n\n\n\n\n\n9",
+    "\n\n0\n\n\n\n\n\n\n0",
+    {
+      "a": 7
+    },
+    "Bksp"
+  ],
+  [
+    {
+      "a": 4
+    },
+    "\n\n`\n\n\n\n\n\n\nTab",
+    "\n\n1\n\n\n\n\n\n\nQ",
+    "\n\n2\n\n\n\n\n\n\nW",
+    "\n\n3\n\n\n\n\n\n\nE",
+    "\n\n4\n\n\n\n\n\n\nR",
+    "\n\n5\n\n\n\n\n\n\nT",
+    {
+      "x": 2
+    },
+    "\n\n6\n\n\n\n\n\n\nY",
+    "\n\n7\n\n\n\n\n\n\nU",
+    "\n\n8\n\n\n\n\n\n\nI",
+    "\n\n9\n\n\n\n\n\n\nO",
+    "\n\n0\n\n\n\n\n\n\nP",
+    {
+      "a": 7
+    },
+    "Del"
+  ],
+  [
+    {
+      "a": 4
+    },
+    "\n\nDel\n\n\n\n\n\n\nEsc",
+    "\n\nF1\n\n\n\n\n\n\nA",
+    "\n\nF2\n\n\n\n\n\n\nS",
+    "\n\nF3\n\n\n\n\n\n\nD",
+    "\n\nF4\n\n\n\n\n\n\nF",
+    "\n\nF5\n\n\n\n\n\n\nG",
+    {
+      "x": 2
+    },
+    "\n\nF6\n\n\n\n\n\n\nH",
+    "\n\n-\n\n\n\n\n\n\nJ",
+    "\n\n=\n\n\n\n\n\n\nK",
+    "\n\n[\n\n\n\n\n\n\nL",
+    "\n\n]\n\n\n\n\n\n\n;",
+    "\n\n\\\n\n\n\n\n\n\n'"
+  ],
+  [
+    {
+      "a": 7
+    },
+    "Shift",
+    {
+      "a": 4
+    },
+    "\n\nF7\n\n\n\n\n\n\nZ",
+    "\n\nF8\n\n\n\n\n\n\nX",
+    "\n\nF9\n\n\n\n\n\n\nC",
+    "\n\nF10\n\n\n\n\n\n\nV",
+    "\n\nF11\n\n\n\n\n\n\nB",
+    {
+      "x": 2
+    },
+    "\n\nF12\n\n\n\n\n\n\nN",
+    "\n\nNUHS\n\n\n\n\n\n\nM",
+    "\n\nNUBS\n\n\n\n\n\n\n,",
+    "\n\nPgUp\n\n\n\n\n\n\n.",
+    "\n\nPgDn\n\n\n\n\n\n\n/",
+    {
+      "a": 7
+    },
+    "Entr"
+  ],
+  [
+    "Fn",
+    "Ctrl",
+    "Alt",
+    "Super",
+    "&dArr;",
+    "",
+    {
+      "x": 2
+    },
+    "",
+    "&uArr;",
+    "&larr;",
+    "&darr;",
+    "&uarr;",
+    "&rarr;"
+  ]
+]

--- a/example_layouts/split_cloud/split_cloud.scad
+++ b/example_layouts/split_cloud/split_cloud.scad
@@ -1,0 +1,113 @@
+include <parameters.scad>
+include <stabilizer_spacing.scad>
+
+/* [Layout Values] */
+/* Layout Format (each key):
+    [
+        [                                       // Location Data
+            [x_location, y_location],
+            key_size,
+            [rotation, rotation_x, rotation_y],
+        ],
+        [                                       // Borders
+            top_border,
+            bottom_border,
+            left_border,
+            right_border
+        ],
+        extra_data                              // Extra data (depending on component type)
+    ]
+*/
+
+// Keyswitch Layout
+//     (extra_data = rotate_column)
+base_switch_layout = [
+  [[[0,0],1,[0,0,0]],[1,1,1,1],false],
+  [[[1,0],1,[0,0,0]],[1,1,1,1],false],
+  [[[2,0],1,[0,0,0]],[1,1,1,1],false],
+  [[[3,0],1,[0,0,0]],[1,1,1,1],false],
+  [[[4,0],1,[0,0,0]],[1,1,1,1],false],
+  [[[5,0],1,[0,0,0]],[1,1,1,1],false],
+  [[[0,1],1,[0,0,0]],[1,1,1,1],false],
+  [[[1,1],1,[0,0,0]],[1,1,1,1],false],
+  [[[2,1],1,[0,0,0]],[1,1,1,1],false],
+  [[[3,1],1,[0,0,0]],[1,1,1,1],false],
+  [[[4,1],1,[0,0,0]],[1,1,1,1],false],
+  [[[5,1],1,[0,0,0]],[1,1,1,1],false],
+  [[[0,2],1,[0,0,0]],[1,1,1,1],false],
+  [[[1,2],1,[0,0,0]],[1,1,1,1],false],
+  [[[2,2],1,[0,0,0]],[1,1,1,1],false],
+  [[[3,2],1,[0,0,0]],[1,1,1,1],false],
+  [[[4,2],1,[0,0,0]],[1,1,1,1],false],
+  [[[5,2],1,[0,0,0]],[1,1,1,1],false],
+  [[[0,3],1,[0,0,0]],[1,1,1,1],false],
+  [[[1,3],1,[0,0,0]],[1,1,1,1],false],
+  [[[2,3],1,[0,0,0]],[1,1,1,1],false],
+  [[[3,3],1,[0,0,0]],[1,1,1,1],false],
+  [[[4,3],1,[0,0,0]],[1,1,1,1],false],
+  [[[5,3],1,[0,0,0]],[1,1,1,1],false],
+  [[[0,4],1,[0,0,0]],[1,1,1,1],false],
+  [[[1,4],1,[0,0,0]],[1,1,1,1],false],
+  [[[2,4],1,[0,0,0]],[1,1,1,1],false],
+  [[[3,4],1,[0,0,0]],[1,1,1,1],false],
+  [[[4,4],1,[0,0,0]],[1,1,1,1],false],
+  [[[5,4],1,[0,0,0]],[1,1,1,1],false],
+];
+
+// MCU Position(s)
+base_mcu_layout = [
+    [[[6.3,0.0524933],1,[0,0,0]],[1,8,1,1],false]
+];
+
+// TRRS Position(s)
+base_trrs_layout = [
+    [[[6.3,2.75],1,[-90,7.05,3.25]],[1,12,1,1]]
+];
+
+// Stabilizer layout
+//     (extra_data = [key_size, left_offset, right_offset, switch_offset=0])
+//     (see stabilizer_spacing.scad for presets)
+base_stab_layout = [];
+
+// Via layout
+//     (extra_data = [via_width, via_length])
+base_via_layout = [
+//    [[[6.75,2.9],0,[-90,6.75,2.9]],[0,0,0,0],[5,10]]
+];
+
+// Plate Layout (if different than PCB)
+//     (extra_data = component_type)
+base_plate_layout = [];
+
+// Whether to only use base_plate_layout to generate the plate footprint
+use_plate_layout_only = false;
+
+// Standoff layout
+//     (extra_data = [standoff_integration_override, standoff_attachment_override])
+base_standoff_layout = [
+    // PCB-Plate standoffs
+    [[[0.5,0.125]]],
+    [[[0.5,4]]],
+    [[[2.5,2]]],
+    [[[4.5,4]]],
+    [[[4.5,0.125]]],
+//    [[[4.875,5.125],1.5,[60,4.875,4.625]], [0,0,0,0]],
+    [[[6.25,1.8]]],
+    // PCB-Backplate standoffs
+    [[[-0.5,-0.375]],[0,0,0,0],["plate", "backplate"]],
+    [[[-0.5,4.625]],[0,0,0,0],["plate", "backplate"]],
+    [[[7.1,3]],[0,0,0,0],["plate", "backplate"]],
+    [[[5.5,4.625]],[0,0,0,0],["plate", "backplate"]],
+    [[[5.5,-0.375]],[0,0,0,0],["plate", "backplate"]],
+    [[[7.1,-0.375]],[0,0,0,0],["plate", "backplate"]],
+//    [[[4.125,6.125],1.5,[60,4.875,4.625]],[0,0,0,0],["plate", "backplate"]],
+//    [[[6.5,3]],[0,0,0,0],["plate", "backplate"]],
+//    [[[5.5,-0.1875]],[0,0,0,0],["plate", "backplate"]],
+//    [[[7,0]],[0,0,0,0],["plate", "backplate"]],
+];
+
+// Whether to flip the layout
+invert_layout_flag = true;
+
+// Whether the layout is staggered-row or staggered-column
+layout_type = "column";  // [column, row]

--- a/scad/README.md
+++ b/scad/README.md
@@ -94,6 +94,7 @@
 ### TRRS Parameters:
 | Name | Description | Location |
 | ---- | ----------- | -------- |
+| `trrs_type` | Type of TRRS or TRS socket used. supported values are `pj320a` for the popular TRRS PJ-320A socket, and `pj324m` for the PJ-324M TRS socket. | `parameters.scad` |
 | `trrs_width` | Width of the TRRS socket in mm. Default value of 6 works for the popular PJ-320A socket. | `parameters.scad` |
 | `trrs_length` | Length of the TRRS socket in mm (not including the round flange). Default value of 12.1 works for the popular PJ-320A socket. | `parameters.scad` |
 | `trrs_height` | Height of the TRRS socket in mm. Default value of 5 works for the popular PJ-320A socket. | `parameters.scad` |

--- a/scad/mcu.scad
+++ b/scad/mcu.scad
@@ -37,11 +37,11 @@ module socketed_mcu(borders=[0,0,0,0]) {
         // Wire Channels
         for (row = [-1,1]) {
             for (pin = [0:mcu_pin_count/2-1]) {
-                translate([row*mcu_row_spacing/2,(pin+0.5)*mcu_pin_pitch,-wire_diameter/3]) 
+                translate([row*mcu_row_spacing/2,(pin+0.5)*mcu_pin_pitch+mcu_pin_offset,-wire_diameter/3]) 
                     cylinder(h=pcb_thickness,d=wire_diameter);
                 translate([
                     row*(mcu_row_spacing/2-1),
-                    (pin+0.5)*mcu_pin_pitch,
+                    (pin+0.5)*mcu_pin_pitch+mcu_pin_offset,
                     pcb_thickness-wire_diameter/3
                 ]) rotate([0,row*90,0])
                     cylinder(h=1000,d=wire_diameter);
@@ -92,7 +92,7 @@ module bare_mcu(borders=[0,0,0,0]) {
             for (pin = [0:mcu_pin_count/2-1]) {
                 translate([
                     row*(mcu_row_spacing/2-1),
-                    (pin+0.5)*mcu_pin_pitch,
+                    (pin+0.5)*mcu_pin_pitch+mcu_pin_offset,
                     pcb_thickness-wire_diameter/3
                 ]) rotate([0,row*90,0])
                     cylinder(h=1000,d=wire_diameter);
@@ -102,7 +102,7 @@ module bare_mcu(borders=[0,0,0,0]) {
         translate([-mcu_width/2,0,pcb_thickness]) 
             cube([mcu_width, mcu_length,mcu_pcb_thickness+1]);
         // Side cutout
-        translate([-(mcu_socket_width+2)/2,0,pcb_thickness]) 
+        translate([-(mcu_socket_width+2)/2,mcu_pin_offset,pcb_thickness]) 
             cube([mcu_socket_width+2,mcu_pin_count/2*mcu_pin_pitch,mcu_pcb_thickness+1]);
         // USB cutout
         translate([-mcu_connector_width/2,-3,pcb_thickness]) 

--- a/scad/parameters.scad
+++ b/scad/parameters.scad
@@ -103,6 +103,7 @@ trrs_nub_spacing = 7;
 trrs_nub_offset = 1.5;  // Distance from the front of the socket (not including flange)
 trrs_plug_width = 10;  // Width of a plug for plate clearance
 
+
 /* TRS Socket Parameters */
 //trrs_type = "pj324m";
 //trrs_width = 11.55;
@@ -116,6 +117,7 @@ trrs_plug_width = 10;  // Width of a plug for plate clearance
 //trrs_nub_spacing = 7;
 //trrs_nub_offset = 1.5;  // Distance from the front of the socket (not including flange)
 //trrs_plug_width = 10;  // Width of a plug for plate clearance
+
 
 /* Via Parameters */
 via_width = 5;

--- a/scad/parameters.scad
+++ b/scad/parameters.scad
@@ -90,6 +90,7 @@ grid_spacing = 1.6;
 
 
 /* TRRS Socket Parameters */
+trrs_type = "pj320a";
 trrs_width = 6;
 trrs_length = 12.1;
 trrs_height = 5;
@@ -102,6 +103,19 @@ trrs_nub_spacing = 7;
 trrs_nub_offset = 1.5;  // Distance from the front of the socket (not including flange)
 trrs_plug_width = 10;  // Width of a plug for plate clearance
 
+/* TRS Socket Parameters */
+//trrs_type = "pj324m";
+//trrs_width = 11.55;
+//trrs_length = 14.25;
+//trrs_height = 6.3;
+//trrs_flange_length = 3.5;
+//trrs_flange_diameter = 6;
+//trrs_pin_spacing = 4.4;
+//trrs_nub_diameter = 1.5;  // Little locating nubs on the bottom of the socket
+//trrs_nub_height = 1;
+//trrs_nub_spacing = 7;
+//trrs_nub_offset = 1.5;  // Distance from the front of the socket (not including flange)
+//trrs_plug_width = 10;  // Width of a plug for plate clearance
 
 /* Via Parameters */
 via_width = 5;

--- a/scad/trrs.scad
+++ b/scad/trrs.scad
@@ -17,6 +17,8 @@ module trrs(borders=[0,0,0,0]) {
                     pj320a_trrs(invert_borders(borders,layout_type == "row"));
                 } else if(trrs_type == "pj324m") {
                     pj324m_trs(invert_borders(borders,layout_type == "row"));
+                } else {
+                    assert(false, "trrs_type is invalid");
                 }
             }
 }

--- a/scad/trrs.scad
+++ b/scad/trrs.scad
@@ -12,8 +12,13 @@ module wire_channel(length=pcb_thickness) {
 module trrs(borders=[0,0,0,0]) {
     translate([h_unit/2,-socket_length,0])
         rotate([0,layout_type == "row"?180:0,0])
-            translate([-socket_width/2,0,-pcb_thickness/2])
-                pj320a_trrs(invert_borders(borders,layout_type == "row"));
+            translate([-socket_width/2,0,-pcb_thickness/2]) {
+                if(trrs_type == "pj320a") {
+                    pj320a_trrs(invert_borders(borders,layout_type == "row"));
+                } else if(trrs_type == "pj324m") {
+                    pj324m_trs(invert_borders(borders,layout_type == "row"));
+                }
+            }
 }
 
 module pj320a_trrs(borders=[0,0,0,0]) {
@@ -63,6 +68,58 @@ module pj320a_trrs(borders=[0,0,0,0]) {
             translate([socket_width/2,4-trrs_flange_length+y,pcb_thickness-2-trrs_nub_height])
                 cylinder(d=trrs_nub_diameter,h=pcb_thickness);
         }
+    }
+}
+
+module pj324m_trs(borders=[0,0,0,0]) {
+
+    difference() {
+        union() {
+            // Socket Base
+            translate([0,-trrs_flange_length/2+1,0])
+                cube([socket_width,socket_length+trrs_flange_length/2-1,pcb_thickness-2+trrs_flange_diameter*2/3]);
+            translate([
+                socket_width/2,
+                socket_length-trrs_flange_length,
+                pcb_thickness-2+trrs_flange_diameter/2
+            ]) rotate([-90,0,0]) intersection() {
+                cylinder(d=trrs_flange_diameter+2,trrs_flange_length);
+                translate([0,0,trrs_flange_length/2]) 
+                    cube([trrs_flange_diameter+2,trrs_flange_diameter/3,trrs_flange_length],center=true);
+            }
+            // Borders
+            translate([socket_width/2,socket_length-v_unit/2,pcb_thickness/2-1])
+                border(
+                    [h_unit,v_unit], 
+                    borders, 
+                    pcb_thickness-2
+                );
+        }
+        // Socket Cutout
+        translate([2,4-trrs_flange_length,pcb_thickness-2]) 
+            cube([trrs_width,trrs_length,trrs_height]);
+        // Flange Cutout
+        translate([
+            socket_width/2-.25,
+            socket_length-1-trrs_flange_length,
+            pcb_thickness-2+trrs_flange_diameter/2
+        ]) rotate([-90,0,0]) 
+            cylinder(d=trrs_flange_diameter,h=trrs_flange_length+2);
+        
+        // Wire Channels
+//        translate([(trrs_width-trrs_pin_spacing)/2+2,4-trrs_flange_length+0.5,0]) 
+//            wire_channel(pcb_thickness+trrs_height-3);
+//        for (y=[1.8,5.8,9.1]) {
+        for( pos = [[-.25,12.5],[-4.85,8.3],[2.35,5.6],[4.95,4.6],[-4.85,1]] ){
+            translate([(trrs_width+pos[0]*2)/2+2,4-trrs_flange_length+pos[1],0]) 
+                wire_channel(pcb_thickness+trrs_height-3);
+        }
+        
+        // Locating Pins
+//        for (y=[trrs_length-trrs_nub_offset,trrs_length-trrs_nub_offset-trrs_nub_spacing]) {
+//            translate([socket_width/2,4-trrs_flange_length+y,pcb_thickness-2-trrs_nub_height])
+//                cylinder(d=trrs_nub_diameter,h=pcb_thickness);
+//        }
     }
 }
 


### PR DESCRIPTION
Thank you for this project! I used it last year to make a keyboard, and was always intending to add the changes to the upstream.

There was a minor bug with the MCU pin offset, but now that's accounted for and I can use my weird off brand pro-micro clones.

I also added support for a TRS socket, the PJ-324M, since that's what I had on hand at the time of construction.

And finally there's the new keyboard, which is a split preonic clone. I had to make some significant changes to the parameters.scad file, so I just moved the altered file to the example folder. I did keep the commented TRS socket settings in the original file, just for future reference.

Let me know if there are any changes I should make, and hopefully this PR is welcome. 

Thanks again!