### PR TITLE
Implement chamfering for concave case profiles (e.g. plate-layout cases)

### DIFF
--- a/scad/backplate.scad
+++ b/scad/backplate.scad
@@ -11,9 +11,13 @@ use <case.scad>
 
 module backplate_footprint(switch_layout, mcu_layout, trrs_layout, plate_layout, stab_layout) {
     case_height = total_thickness - backplate_case_flange;
-    bottom_offset = use_plate_layout_only
-        ? 0
-        : tan(case_wall_draft_angle) * (case_height-case_base_height);
+
+    // Additional wall thickness introduced by draft angle
+    bottom_offset = (
+        tan(case_wall_draft_angle) *
+        (case_height-case_base_height) // Height of the drafted part of the wall
+    );
+
     if (tent_angle_x == 0 && tent_angle_y == 0) {
         offset(bottom_offset)
             plate_footprint(switch_layout, mcu_layout, trrs_layout, plate_layout, stab_layout);

--- a/scad/parameters.scad
+++ b/scad/parameters.scad
@@ -34,11 +34,11 @@ stabilizer_type = "pcb";  // [pcb, plate]
 case_type = "plate_case";  // [sandwich, plate_case, backplate_case]
 // Thickness of case walls
 case_wall_thickness = 4;
-// Case wall draft angle (convex cases only)
+// Case wall draft angle
 case_wall_draft_angle = 15;
-// Width of the case chamfer (convex cases only)
+// Width of the case chamfer
 case_chamfer_width = 1;
-// Angle of the case chamfer (convex cases only)
+// Angle of the case chamfer
 case_chamfer_angle = 45;
 // Height of the vertical portion at the bottom of the case 
 // (not including backplate flange)

--- a/script/index.js
+++ b/script/index.js
@@ -12,8 +12,10 @@ try {
     console.error(err);
 }
 
+// Parse KLE file
 var keyboard = kle.Serial.parse(kle_json);
 
+// Convert KLE data to the desired format
 var formatted_keys = keyboard.keys.map(
     key => {
         let side_border = ((key.width-1)/2);
@@ -26,7 +28,7 @@ var formatted_keys = keyboard.keys.map(
             [
                 1,
                 1,
-                side_border ? "1+" + side_border.toString() + "*unit*mm" : 1,
+                side_border ? "1+" + side_border.toString() + "*unit*mm" : 1, // adjust side borders for wide keys
                 side_border ? "1+" + side_border.toString() + "*unit*mm" : 1,
             ],
             false
@@ -68,7 +70,12 @@ use <utils.scad>
 //     (extra_data = rotate_column)
 `
 file_content += formatted_keys.reduce(
-    (total, key) => total + "  " + JSON.stringify(key).replace(/"/g, "") + ",\n",
+    (total, key) => (
+        total +  // Output accumulator
+        "  " +   // Indentation
+        JSON.stringify(key).replace(/"/g, "") + // Key data
+        ",\n"  // End of line
+    ),
     "base_switch_layout = [\n"
 );
 file_content +=
@@ -85,9 +92,20 @@ base_trrs_layout = [];
 //     (see stabilizer_spacing.scad for presets)
 `
 file_content += formatted_keys.filter((k) => k[0][1] >= 2).reduce(
-    (total, key) => total + "  " + JSON.stringify([key[0], key[1], "stab_" + JSON.stringify(key[0][1]).replace('.', '_') + "u"]).replace(/"/g, "") + ",\n",
+    (total, key) => (
+        total +  // Output accumulator
+        "  " +   // Indentation
+        JSON.stringify([
+            key[0], // Key position
+            key[1], // Key rotation
+            `stab_${key[0][1].toString().replace('.', '_')}u`, // Convert key width to default stabilizer constant
+        ]).replace(/"/g, "") +
+        ",\n"  // End of line
+    ),
     "base_stab_layout = [\n"
 );
+
+// Rest of the standard data
 file_content +=
 `];
 


### PR DESCRIPTION
Enables chamfers and draft angles for cases defined using `plate_layout`, including concave profiles (this feature was previously limited to cases created by hulling the switch layout). Corners are rounded, since this is implemented using `minkowski()` on a cone.

Example:
![image](https://github.com/user-attachments/assets/49575fbd-1a63-4ab2-ad00-cf2acc1ecc3f)
