### PR TITLE
Add fillets to the bases of standoffs to improve strength

### DIFF
--- a/scad/parameters.scad
+++ b/scad/parameters.scad
@@ -127,6 +127,8 @@ standoff_clearance_hole_diameter = 2.5;
 standoff_pilot_hole_diameter = 1.6;
 // Diameter of standoff screw head counterbores
 standoff_counterbore_diameter = 4.5;
+// Radius of the fillet at the base of standoffs
+default_standoff_fillet=1;
 
 
 // Cutout Grid Parameters

--- a/scad/switch.scad
+++ b/scad/switch.scad
@@ -249,7 +249,7 @@ module switch_plate_base(borders=[1,1,1,1], thickness=plate_thickness) {
 }
 
 module switch_plate_cutout(thickness=plate_thickness) {
-    linear_extrude(thickness+1, center=true)
+    linear_extrude(thickness+2*total_thickness, center=true)
         switch_plate_cutout_footprint();
 }
 


### PR DESCRIPTION
The standoffs on my printed cases frequently break off due to mediocre print quality/layer adhesion, a very small attachment area, and increased stresses at the right angle. This PR adds a configurable fillet to the base of each standoff that should increase the attachment area and also eliminate a stress riser. I also got a better 3D printer, so that should fix the first problem (not fixed in this PR).

Example:
![image](https://github.com/user-attachments/assets/aebe4fb9-3baf-423d-8583-46f96a0c24cc)
